### PR TITLE
Get scan date from alternative part of twix file if not in normal place

### DIFF
--- a/utils/twix_utils.py
+++ b/utils/twix_utils.py
@@ -24,7 +24,7 @@ def get_scan_date(twix_obj: mapvbvd._attrdict.AttrDict) -> str:
     try:
         tReferenceImage0 = str(twix_obj.hdr.MeasYaps[("tReferenceImage0",)]).strip('"')
         scan_date = tReferenceImage0.split(".")[-1][:8]
-    except:
+    except KeyError:
         SeriesLOID = twix_obj.hdr.Config[("SeriesLOID")]
         scan_date = SeriesLOID.split(".")[-4][:8]
     return scan_date[:4] + "-" + scan_date[4:6] + "-" + scan_date[6:]


### PR DESCRIPTION
Some scans have missing scan date in the usual place. If that is the case, this change has the code look in alternative spot of twix header.