### PR TITLE
add ability to reconstruct only gas images, without proton in config …

### DIFF
--- a/config/base_config.py
+++ b/config/base_config.py
@@ -76,6 +76,9 @@ class Recon(object):
         del_z: str, the z direction gradient delay in microseconds
         traj_type: str, the trajectory type
         recon_key: str, the reconstruction key
+        recon_proton: bool, whether to reconstruct proton images
+        remove_contamination: bool, whether to remove gas contamination
+        remove_noisy_projections: bool, whether to remove noisy projections
         scan_type: str, the scan type
         kernel_sharpness_lr: float, the kernel sharpness for low resolution, higher
             SNR images
@@ -84,6 +87,7 @@ class Recon(object):
         n_skip_start: int, the number of frames to skip at the beginning
         n_skip_end: int, the number of frames to skip at the end
         key_radius: int, the key radius for the keyhole image
+        matrix_size: int, the final matrix size
     """
 
     def __init__(self):

--- a/config/demo_config_advanced.py
+++ b/config/demo_config_advanced.py
@@ -70,6 +70,7 @@ class Recon(base_config.Recon):
         self.del_x = 0
         self.del_y = 0
         self.del_z = 0
+        self.recon_proton = False
 
 
 class ReferenceData(base_config.ReferenceData):

--- a/main.py
+++ b/main.py
@@ -1,6 +1,8 @@
 """Scripts to run gas exchange mapping pipeline."""
+
 import logging
 
+import numpy as np
 from absl import app, flags
 from ml_collections import config_flags
 
@@ -37,6 +39,8 @@ def gx_mapping_reconstruction(config: base_config.Config):
     subject.reconstruction_dissolved()
     if config.recon.recon_proton:
         subject.reconstruction_ute()
+    else:
+        subject.image_proton = np.zeros_like(subject.image_gas_highreso)
     subject.segmentation()
     subject.registration()
     subject.biasfield_correction()


### PR DESCRIPTION
Addresses issue #38 

This is a simple fix where I am setting the proton image to an array of zeros if the config specifies to not reconstruction the proton image.

Result is below:
![image](https://github.com/TeamXenonDuke/xenon-gas-exchange-consortium/assets/13774060/55b895b1-c548-4ef4-a06a-7c87fdc84648)
