### PR TITLE
did not set grad delay in normal dixon w/ bonus spectra case

### DIFF
--- a/utils/twix_utils.py
+++ b/utils/twix_utils.py
@@ -528,8 +528,8 @@ def get_gx_data(twix_obj: mapvbvd._attrdict.AttrDict) -> Dict[str, Any]:
             data_gas = raw_fids[:-num_spectra][0::2, :]
             data_dis = raw_fids[:-num_spectra][1::2, :]
             n_frames = data_dis.shape[0]
-            n_skip_start = 1
-            n_skip_end = num_spectra
+            n_skip_start = 0
+            n_skip_end = 0
             grad_delay_x, grad_delay_y, grad_delay_z = -5, -5, -5
         else:
             raise ValueError("Cannot get data from normal dixon twix object.")


### PR DESCRIPTION
Addresses issue causing grad delay error caused by value not being set manually