### PR TITLE
Adding "h_radial" to UTE twix file searching list in io_utils.py

### DIFF
--- a/utils/io_utils.py
+++ b/utils/io_utils.py
@@ -127,6 +127,7 @@ def get_ute_twix_files(path: str) -> str:
             glob.glob(os.path.join(path, "**1H***.dat"))
             + glob.glob(os.path.join(path, "**BHUTE***.dat"))
             + glob.glob(os.path.join(path, "**ute***.dat"))
+            + glob.glob(os.path.join(path, "**h_radial***.dat"))
         )[0]
     except:
         raise ValueError("Can't find twix file in path.")


### PR DESCRIPTION
Adding "h_radial" to UTE twix file searching list io_utils.py as our new twix file naming convention.