### PR TITLE
Address issue #91 - RGB artifacts removal

### DIFF
--- a/utils/io_utils.py
+++ b/utils/io_utils.py
@@ -542,14 +542,7 @@ def export_nii(image: np.ndarray, path: str, fov: Optional[float] = None):
             fov / np.shape(image)[0] / 10,
         ]
     nib.save(nii_imge, path)
-import matplotlib.pyplot as plt
 
-def save_debug_image(image, filename, cmap="gray"):
-    """Save a 2D slice of a 3D or 4D image for debugging."""
-    plt.imshow(image, cmap=cmap)
-    plt.axis("off")
-    plt.savefig(filename, bbox_inches="tight", pad_inches=0)
-    plt.close()
 
 def export_nii_4d(image, path, fov=None):
     """Export 4d image image as nifti file.
@@ -570,7 +563,6 @@ def export_nii_4d(image, path, fov=None):
     cline = np.reshape(color, (1, np.size(color)))
     color = np.reshape(cline, np.shape(image), order="A")
     color = np.transpose(color, [2, 1, 0, 3])
-
     # stake the RGB channels
     shape_3d = image.shape[0:3]
     rgb_dtype = np.dtype([("R", "u1"), ("G", "u1"), ("B", "u1")])

--- a/utils/io_utils.py
+++ b/utils/io_utils.py
@@ -542,7 +542,14 @@ def export_nii(image: np.ndarray, path: str, fov: Optional[float] = None):
             fov / np.shape(image)[0] / 10,
         ]
     nib.save(nii_imge, path)
+import matplotlib.pyplot as plt
 
+def save_debug_image(image, filename, cmap="gray"):
+    """Save a 2D slice of a 3D or 4D image for debugging."""
+    plt.imshow(image, cmap=cmap)
+    plt.axis("off")
+    plt.savefig(filename, bbox_inches="tight", pad_inches=0)
+    plt.close()
 
 def export_nii_4d(image, path, fov=None):
     """Export 4d image image as nifti file.
@@ -552,12 +559,24 @@ def export_nii_4d(image, path, fov=None):
         path: str file path of nifti file
         fov: float field of view in cm
     """
-    color = (np.copy(image) * 255).astype("uint8")  # need uint8 to save to RGB
+    # color = (np.copy(image) * 255).astype("uint8")  # need uint8 to save to RGB
+    color = np.copy(image)
+
+    # Normalize only if image is not in the expected range
+    if color.max() > 1:
+        color = (color / color.max()) * 255  # Normalize to [0, 255] only if needed
+
+    color = color.astype("uint8")
+
+    save_debug_image(color[:, :, color.shape[2] // 2, 0], "/Users/hong/Pipeline/patients/009-037/noair/debug_color_mid_slice.png")
+
     # some fancy and tricky re-arrange
     color = np.transpose(color, [2, 3, 0, 1])
     cline = np.reshape(color, (1, np.size(color)))
     color = np.reshape(cline, np.shape(image), order="A")
     color = np.transpose(color, [2, 1, 0, 3])
+    save_debug_image(color[:, :, color.shape[2] // 2, 0], "/Users/hong/Pipeline/patients/009-037/noair/debug_color_mid_slice_after_transpose.png")
+
     # stake the RGB channels
     shape_3d = image.shape[0:3]
     rgb_dtype = np.dtype([("R", "u1"), ("G", "u1"), ("B", "u1")])

--- a/utils/io_utils.py
+++ b/utils/io_utils.py
@@ -552,11 +552,9 @@ def export_nii_4d(image, path, fov=None):
         path: str file path of nifti file
         fov: float field of view in cm
     """
-    color = np.copy(image)
-    # Normalize only if image is not in the expected range
-    if color.max() > 1:
-        color = (color / color.max()) * 255  # Normalize to [0, 255] only if needed
-    color = color.astype("uint8")
+    # Scale values and clip to ensure they stay in the [0, 255] range
+    color = np.copy(image)*255  
+    color = np.clip(color, 0, 255).astype("uint8")
 
     # some fancy and tricky re-arrange
     color = np.transpose(color, [2, 3, 0, 1])

--- a/utils/io_utils.py
+++ b/utils/io_utils.py
@@ -559,23 +559,17 @@ def export_nii_4d(image, path, fov=None):
         path: str file path of nifti file
         fov: float field of view in cm
     """
-    # color = (np.copy(image) * 255).astype("uint8")  # need uint8 to save to RGB
     color = np.copy(image)
-
     # Normalize only if image is not in the expected range
     if color.max() > 1:
         color = (color / color.max()) * 255  # Normalize to [0, 255] only if needed
-
     color = color.astype("uint8")
-
-    save_debug_image(color[:, :, color.shape[2] // 2, 0], "/Users/hong/Pipeline/patients/009-037/noair/debug_color_mid_slice.png")
 
     # some fancy and tricky re-arrange
     color = np.transpose(color, [2, 3, 0, 1])
     cline = np.reshape(color, (1, np.size(color)))
     color = np.reshape(cline, np.shape(image), order="A")
     color = np.transpose(color, [2, 1, 0, 3])
-    save_debug_image(color[:, :, color.shape[2] // 2, 0], "/Users/hong/Pipeline/patients/009-037/noair/debug_color_mid_slice_after_transpose.png")
 
     # stake the RGB channels
     shape_3d = image.shape[0:3]

--- a/utils/plot.py
+++ b/utils/plot.py
@@ -96,6 +96,11 @@ def get_biggest_island_indices(arr: np.ndarray) -> Tuple[int, int]:
 
     return index_start, index_end
 
+def save_debug_image(image, filename, cmap="gray"):
+    plt.imshow(image, cmap=cmap)
+    plt.axis("off")
+    plt.savefig(filename, bbox_inches="tight", pad_inches=0)
+    plt.close()
 
 def map_and_overlay_to_rgb(
     image: np.ndarray, image_background: np.ndarray, cmap: Dict[int, np.ndarray]
@@ -109,12 +114,17 @@ def map_and_overlay_to_rgb(
     Returns:
         RGB image of shape (x, y, z, 3)
     """
+    # save_debug_image(image[:,:,65], "/Users/hong/Pipeline/patients/009-037/noair/input_image_slice65.png")
+    # save_debug_image(image_background[:,:,65], "/Users/hong/Pipeline/patients/009-037/noair/background_slice65.png")
     image_rgb = map_grey_to_rgb(image, cmap)
     image_out = np.zeros((image.shape[0], image.shape[1], image.shape[2], 3))
     for i in range(0, image.shape[2]):
         image_out[:, :, i, :] = _merge_rgb_and_gray(
             image_background[:, :, i], image_rgb[:, :, i, :]
         )
+    # save_debug_image(image_rgb[:,:,65], "/Users/hong/Pipeline/patients/009-037/noair/rgb_slice65.png")
+    # save_debug_image(image_out[:,:,65,:], "/Users/hong/Pipeline/patients/009-037/noair/output_slice65.png")
+
     return image_out
 
 

--- a/utils/plot.py
+++ b/utils/plot.py
@@ -114,16 +114,12 @@ def map_and_overlay_to_rgb(
     Returns:
         RGB image of shape (x, y, z, 3)
     """
-    # save_debug_image(image[:,:,65], "/Users/hong/Pipeline/patients/009-037/noair/input_image_slice65.png")
-    # save_debug_image(image_background[:,:,65], "/Users/hong/Pipeline/patients/009-037/noair/background_slice65.png")
     image_rgb = map_grey_to_rgb(image, cmap)
     image_out = np.zeros((image.shape[0], image.shape[1], image.shape[2], 3))
     for i in range(0, image.shape[2]):
         image_out[:, :, i, :] = _merge_rgb_and_gray(
             image_background[:, :, i], image_rgb[:, :, i, :]
         )
-    # save_debug_image(image_rgb[:,:,65], "/Users/hong/Pipeline/patients/009-037/noair/rgb_slice65.png")
-    # save_debug_image(image_out[:,:,65,:], "/Users/hong/Pipeline/patients/009-037/noair/output_slice65.png")
 
     return image_out
 

--- a/utils/plot.py
+++ b/utils/plot.py
@@ -96,11 +96,6 @@ def get_biggest_island_indices(arr: np.ndarray) -> Tuple[int, int]:
 
     return index_start, index_end
 
-def save_debug_image(image, filename, cmap="gray"):
-    plt.imshow(image, cmap=cmap)
-    plt.axis("off")
-    plt.savefig(filename, bbox_inches="tight", pad_inches=0)
-    plt.close()
 
 def map_and_overlay_to_rgb(
     image: np.ndarray, image_background: np.ndarray, cmap: Dict[int, np.ndarray]
@@ -120,7 +115,6 @@ def map_and_overlay_to_rgb(
         image_out[:, :, i, :] = _merge_rgb_and_gray(
             image_background[:, :, i], image_rgb[:, :, i, :]
         )
-
     return image_out
 
 


### PR DESCRIPTION
A certain slices of the proton background of RGB nifti files produced by GX pipeline showing saturation artifacts. 
The main reason for this issue is when it tries to export 4D image as nifti file, it takes the input image as normalized by default and then multiply 255. However, the image has to be normalized before multiply 255. And after normalization, the artifacts gone.