### PR TITLE
set skip noisy fids to False as default

### DIFF
--- a/assets/html/intro.html
+++ b/assets/html/intro.html
@@ -138,21 +138,21 @@
 
         <tr class="basic">
           <td>
-            <p>Remove noisy projections</p>
+            <p>Remove noisy FIDs</p>
           </td>
           <td>{remove_noise}</td>
         </tr>
 
         <tr class="basic">
           <td>
-            <p>Removed Spike Noise FIDs (Gas)</p>
+            <p>Detected Spike Noise FIDs (Gas)</p>
           </td>
           <td>{n_gas_removed}</td>
         </tr>
 
         <tr class="basic">
           <td>
-            <p>Removed Spike Noise FIDs (Dissolved)</p>
+            <p>Detected Spike Noise FIDs (Dissolved)</p>
           </td>
           <td>{n_dis_removed}</td>
         </tr>

--- a/config/base_config.py
+++ b/config/base_config.py
@@ -103,7 +103,7 @@ class Recon(object):
         self.n_skip_start = np.nan
         self.n_skip_end = 0
         self.remove_contamination = False
-        self.remove_noisy_projections = True
+        self.remove_noisy_projections = False
         self.traj_type = constants.TrajType.HALTONSPIRAL
 
 


### PR DESCRIPTION
1. set skip noisy fids to False as default.
2. Cover page changes: 
      - [1] "Remove noisy projections" -> "Remove noisy FIDs"
      - [2] "Removed Spike Noise FIDs (Gas)" -> "Detected Spike Noise FIDs (Gas)"
      - [3] "Removed Spike Noise FIDs (Dissolved)" -> "Detected Spike Noise FIDs (Dissolved)"
