### PR TITLE
add sagittal axial transverse orientations to make pipeline capable t…

### DIFF
--- a/utils/constants.py
+++ b/utils/constants.py
@@ -225,6 +225,7 @@ class Orientation(object):
     CORONAL = "coronal"
     AXIAL = "axial"
     TRANSVERSE = "transverse"
+    SAGITAL = "sagittal"
     NONE = "none"
 
 

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -225,7 +225,7 @@ class Orientation(object):
     CORONAL = "coronal"
     AXIAL = "axial"
     TRANSVERSE = "transverse"
-    SAGITAL = "sagittal"
+    SAGITTAL = "sagittal"
     NONE = "none"
 
 

--- a/utils/img_utils.py
+++ b/utils/img_utils.py
@@ -96,7 +96,7 @@ def flip_and_rotate_image(
             image = np.rot90(image, 1, axes=(0, 1))
             image = np.flip(np.flip(image, axis=1), axis=2)
             return image
-        elif orientation == constants.Orientation.SAGITAL:
+        elif orientation == constants.Orientation.SAGITTAL:
             return rotate_sagittal_to_coronal(flip_image_complex(image))
         elif orientation == constants.Orientation.TRANSVERSE:
             return rotate_axial_to_coronal(flip_image_complex(image))

--- a/utils/img_utils.py
+++ b/utils/img_utils.py
@@ -62,6 +62,19 @@ def rotate_axial_to_coronal(image: np.ndarray) -> np.ndarray:
     imag = ndimage.rotate(ndimage.rotate(np.imag(image), 90, (1, 2)), 270)
     return real + 1j * imag
 
+def rotate_sagittal_to_coronal(image: np.ndarray) -> np.ndarray:
+    """Rotate sagittal image to coronal.
+
+    Image is assumed to be of complex datatype.
+
+    Args:
+        image (np.ndarray): image viewed in sagittal orientation.
+    Returns:
+        Rotated coronal image.
+    """
+    real = ndimage.rotate(ndimage.rotate(np.real(image), 90, (1, 2)), 180)
+    imag = ndimage.rotate(ndimage.rotate(np.imag(image), 90, (1, 2)), 180)
+    return real + 1j * imag
 
 def flip_and_rotate_image(
     image: np.ndarray, orientation: str = constants.Orientation.CORONAL,
@@ -83,6 +96,8 @@ def flip_and_rotate_image(
             image = np.rot90(image, 1, axes=(0, 1))
             image = np.flip(np.flip(image, axis=1), axis=2)
             return image
+        elif orientation == constants.Orientation.SAGITAL:
+            return rotate_sagittal_to_coronal(flip_image_complex(image))
         elif orientation == constants.Orientation.TRANSVERSE:
             return rotate_axial_to_coronal(flip_image_complex(image))
         elif orientation == constants.Orientation.AXIAL:

--- a/utils/mrd_utils.py
+++ b/utils/mrd_utils.py
@@ -309,7 +309,7 @@ def get_orientation(header: ismrmrd.xsd.ismrmrdschema.ismrmrd.ismrmrdHeader) -> 
         constants.Orientation.CORONAL,
         constants.Orientation.AXIAL,
         constants.Orientation.TRANSVERSE,
-        constants.Orientation.SAGITAL,
+        constants.Orientation.SAGITTAL,
     }
     if system_vendor in supported_vendors and orientation in valid_orientations:
         return orientation

--- a/utils/mrd_utils.py
+++ b/utils/mrd_utils.py
@@ -297,16 +297,23 @@ def get_orientation(header: ismrmrd.xsd.ismrmrdschema.ismrmrd.ismrmrdHeader) -> 
         ].value
     except:
         logging.info("Unable to find orientation from twix object, returning coronal.")
+    
+    orientation = orientation.lower() if orientation else ""
 
-    if system_vendor == constants.SystemVendor.PHILIPS.value:
-        if orientation.lower() == constants.Orientation.CORONAL or not orientation:
-            return constants.Orientation.CORONAL
-    elif system_vendor == constants.SystemVendor.GE.value:
-        if orientation.lower() == constants.Orientation.CORONAL or not orientation:
-            return constants.Orientation.CORONAL
-    else:
-        if orientation.lower() == constants.Orientation.CORONAL or not orientation:
-            return constants.Orientation.CORONAL
+    supported_vendors = {
+        constants.SystemVendor.SIEMENS.value,
+        constants.SystemVendor.PHILIPS.value,
+        constants.SystemVendor.GE.value,
+    }
+    valid_orientations = {
+        constants.Orientation.CORONAL,
+        constants.Orientation.AXIAL,
+        constants.Orientation.TRANSVERSE,
+        constants.Orientation.SAGITAL,
+    }
+    if system_vendor in supported_vendors and orientation in valid_orientations:
+        return orientation
+    return constants.Orientation.CORONAL
 
 
 def get_protocol_name(header: ismrmrd.xsd.ismrmrdschema.ismrmrd.ismrmrdHeader) -> str:


### PR DESCRIPTION
Our pipeline currently only can deal with coronal orientation. But it should be capable to handle different orientations: axial, sagittal, transverse and coronal. There are two steps:

1. To recognize and process orientations: coronal, axial, by adding "sagittal" to constants.py and adding axial, transverse and sagittal orientations in function "get_orientation()" in mrd_utils.py.
2. Correct the rotation of gas images to match the proton images in img_utils.py.