### PR TITLE
Increase DPI for New PNGs

### DIFF
--- a/utils/report.py
+++ b/utils/report.py
@@ -120,7 +120,7 @@ def clinical(dict_stats: Dict[str, Any], path: str):
         base_url=str(project_root)
     ).write_pdf(
         target=path,
-        dpi=96,
+        dpi=300,
     )
 
 
@@ -157,7 +157,7 @@ def grayscale(dict_stats: Dict[str, Any], path: str):
         base_url=str(project_root)
     ).write_pdf(
         target=path,
-        dpi=96,
+        dpi=300,
     )
 
 
@@ -194,7 +194,7 @@ def grayscale_cor(dict_stats: Dict[str, Any], path: str):
         base_url=str(project_root)
     ).write_pdf(
         target=path,
-        dpi=96,
+        dpi=300,
     )
 
 
@@ -231,7 +231,7 @@ def intro(dict_info: Dict[str, Any], path: str):
         base_url=str(project_root)
     ).write_pdf(
         target=path,
-        dpi=96,
+        dpi=300,
     )
 
 
@@ -268,7 +268,7 @@ def qa(dict_stats: Dict[str, Any], path: str):
         base_url=str(project_root)
     ).write_pdf(
         target=path,
-        dpi=96,
+        dpi=300,
     )
 
 


### PR DESCRIPTION
## Summary

<!-- What does this PR do? -->
Improve resolution of gx report images. Original changes for the WeasyPrint transition had DPI tailored for the old histograms. The new, colorful histograms are much higher res, so the low DPI setting in the code caused pixels to crunch. The montage was also blurry, but I didn't notice during original dev.

## Changes

<!-- What features/files were changed? -->

* report.py - change dpi from 96 to 300 for all 5 PDF rendering functions

## Testing Instructions

<!-- How do we ensure the code works as expected? -->

1. Run pipeline on subject of your choosing
2. Open gx report pdf
3. zoom in on histograms/montages & make sure images are clear

## Screenshots (if applicable)

<img width="1505" height="749" alt="image" src="https://github.com/user-attachments/assets/38e8f68a-f8db-4f66-9911-42f925d17f8e" />

