### PR TITLE
Add proton segmentation and Fix Mask2Gas Registration

### DIFF
--- a/registration.py
+++ b/registration.py
@@ -110,7 +110,7 @@ def register_ants(
     # call the command to apply transformation to image_transform
     os.system(cmd_applyTransform)
     try:
-        moving2_reg = np.around(np.array(nib.load(pathOutputmoving2).get_fdata()))
+        moving2_reg = np.array(nib.load(pathOutputmoving2).get_fdata())
     except FileNotFoundError:
         raise Exception(
             "registration failed, could not find antsRegistration executable"

--- a/segmentation.py
+++ b/segmentation.py
@@ -42,19 +42,21 @@ def predict(
     else:
         raise ValueError("Segmentation Image size should be 128 x 128 x n")
 
+    model = vnet(input_size=(128, 128, 128, 1))
+
     if image_type == constants.ImageType.VENT.value:
-        model = vnet(input_size=(128, 128, 128, 1))
         weights_dir_current = "./models/weights/model_ANATOMY_VEN.h5"
+    elif image_type == constants.ImageType.UTE.value:
+        weights_dir_current = "./models/weights/model_ANATOMY_UTE_fixed.h5"
     else:
         raise ValueError("image_type must be ute or vent")
 
     # Load model weights
     model.load_weights(weights_dir_current)
 
-    if image_type == constants.ImageType.VENT.value:
-        image = img_utils.standardize_image(image)
-    else:
-        raise ValueError("Image type must be ute or vent")
+    # Normalize input to 0-255, then subtract the mean and divide by the standard deviation
+    image = img_utils.standardize_image(image)
+
     # Model Prediction
     image = image[None, ...]
     image = image[..., None]

--- a/segmentation.py
+++ b/segmentation.py
@@ -47,7 +47,7 @@ def predict(
     if image_type == constants.ImageType.VENT.value:
         weights_dir_current = "./models/weights/model_ANATOMY_VEN.h5"
     elif image_type == constants.ImageType.UTE.value:
-        weights_dir_current = "./models/weights/model_ANATOMY_UTE_fixed.h5"
+        weights_dir_current = "./models/weights/model_ANATOMY_UTE.h5"
     else:
         raise ValueError("image_type must be ute or vent")
 

--- a/subject_classmap.py
+++ b/subject_classmap.py
@@ -466,11 +466,21 @@ class Subject(object):
             )
 
         if self.config.segmentation_key == constants.SegmentationKey.CNN_VENT.value:
-            logging.info("Performing neural network segmentation.")
-            self.mask = segmentation.predict(self.image_gas_highreso).astype(bool)
+            logging.info("Performing ventilation neural network segmentation.")
+            self.mask = segmentation.predict(self.image_gas_highreso, constants.ImageType.VENT.value).astype(bool)
 
             # Build include-trachea mask automatically (unless user provided one)
             self.mask_include_trachea = get_or_make_mask_include_trachea()
+
+        elif self.config.segmentation_key == constants.SegmentationKey.CNN_PROTON.value:
+            if self.config.recon.recon_proton:
+                logging.info("Performing proton neural network segmentation.")
+                self.mask = segmentation.predict(self.image_proton, constants.ImageType.UTE.value).astype(bool)
+
+                # Build include-trachea mask automatically (unless user provided one)
+                self.mask_include_trachea = get_or_make_mask_include_trachea()
+            else:
+                logging.error("Proton reconstruction is set to False. Proton segmentation cannot be performed.")
 
         elif self.config.segmentation_key == constants.SegmentationKey.SKIP.value:
             self.mask = np.ones_like(self.image_gas_highreso, dtype=bool)
@@ -495,11 +505,21 @@ class Subject(object):
 
         Uses ANTs registration to register the proton image to the xenon image.
         """
+
         if self.config.registration_key == constants.RegistrationKey.MASK2GAS.value:
-            logging.info("Run registration algorithm, vent is fixed, mask is moving")
-            self.mask, self.image_proton_reg = np.abs(
+            logging.info("Run registration algorithm, vent is fixed, proton mask is moving")
+
+            if self.config.segmentation_key in [constants.SegmentationKey.CNN_PROTON.value, constants.SegmentationKey.MANUAL_PROTON.value]:
+                self.mask_proton = self.mask
+            else:
+                if self.config.recon.recon_proton:
+                    self.mask_proton = segmentation.predict(self.image_proton, constants.ImageType.UTE.value).astype(bool)
+                else:
+                    logging.error("Proton reconstruction is disabled. Cannot perform proton mask-to-gas registration.")
+
+            mask, self.image_proton_reg = np.abs(
                 registration.register_ants(
-                    abs(self.image_gas_highreso), self.mask, self.image_proton
+                    abs(self.image_gas_highreso), self.mask_proton, self.image_proton
                 )
             )
         elif self.config.registration_key == constants.RegistrationKey.PROTON2GAS.value:
@@ -509,13 +529,7 @@ class Subject(object):
                     abs(self.image_gas_highreso), self.image_proton, self.mask
                 )
             )
-            if (
-                self.config.segmentation_key
-                == constants.SegmentationKey.CNN_PROTON.value
-                or self.config.segmentation_key
-                == constants.SegmentationKey.MANUAL_PROTON.value
-            ):
-                self.mask = mask
+
         elif self.config.registration_key == constants.RegistrationKey.MANUAL.value:
             # Load a file specified by the user
             try:
@@ -530,6 +544,21 @@ class Subject(object):
             self.image_proton_reg = self.image_proton
         else:
             raise ValueError("Invalid registration key.")
+
+
+        # Use the registered mask when the segmentation comes from a proton image
+        # and registration to gas space was performed.   
+
+        if (
+            self.config.segmentation_key
+            in [
+                constants.SegmentationKey.CNN_PROTON.value,
+                constants.SegmentationKey.MANUAL_PROTON.value,
+            ]
+            and self.config.registration_key != constants.RegistrationKey.SKIP.value
+            ):
+            mask = np.around(mask)
+            self.mask = mask
 
         def convert_and_threshold_mask(mask):
             """
@@ -967,7 +996,7 @@ class Subject(object):
         """Export image figures."""
         index_start, index_skip = plot.get_plot_indices(self.mask)
         proton_reg = img_utils.normalize(
-            np.abs(self.image_proton),
+            np.abs(self.image_proton_reg),
             self.mask,
             bag_volume=self.config.bag_volume,
             method=constants.NormalizationMethods.PERCENTILE,

--- a/subject_classmap.py
+++ b/subject_classmap.py
@@ -486,7 +486,7 @@ class Subject(object):
             self.mask = np.ones_like(self.image_gas_highreso, dtype=bool)
             self.mask_include_trachea = self.mask.copy()
 
-        elif self.config.segmentation_key == constants.SegmentationKey.MANUAL_VENT.value:
+        elif self.config.segmentation_key in [constants.SegmentationKey.MANUAL_VENT.value, constants.SegmentationKey.MANUAL_PROTON.value]:
             logging.info("Loading manual mask file specified by the user.")
             loaded_mask = np.squeeze(
                 np.array(nib.load(self.config.manual_seg_filepath).get_fdata())


### PR DESCRIPTION
## Summary

This PR adds support for proton-based segmentation in the new pipeline and fixes related registration behavior. It updates the workflow so proton segmentation is only used when proton reconstruction is available, improves error logging for missing proton reconstruction, and ensures MASK2GAS registration strictly uses the proton-derived mask rather than a ventilation mask.

## Changes

<!-- What features/files were changed? -->

* Added handling for proton-based segmentation paths (`CNN_PROTON` and `MANUAL_PROTON`).
* Added/updated logic to generate the include-trachea mask for proton segmentation.
* Improved error messages when proton reconstruction is disabled or unavailable.
* Fixed MASK2GAS registration to strictly use the proton mask.
* Updated mask assignment logic so the registered mask is used for proton segmentation when registration is performed.
* Cleaned up related condition checks for readability and consistency.

## Testing Instructions

<!-- How do we ensure the code works as expected? -->
1. Test `CNN_PROTON` with `MASK2GAS` registration and confirm the registered proton mask is used.
2. Test `CNN_PROTON` with `PROTON2GAS` registration and confirm registration completes correctly.
3. Test `CNN_VENT` and confirm the existing ventilation-based workflow is unchanged.
4. Test manual mask input and confirm registration/mask handling still behaves correctly.
5. Test `CNN_PROTON` with proton reconstruction disabled and confirm the expected error is logged.

## Tester need to download the new weight name model_ANATOMY_UTE_fixed.h5 then change the name to model_ANATOMY_UTE.h5 to replace the previous weight
