### PR TITLE
Remove README references to demo_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ More information on consortium protocol for the proton UTE, 1-point Dixon, and c
 
 #### 3.1.2 Config file
 
-All subject information and processing parameters are specified in a subject-specific configuration file. Default configuration settings are defined in `config/base_config.py`, which can be duplicated and modified to be a subject-specific config file. The standard config parameters in the file must be filled per subject. The defaults in `base_config.py` are inhereted by subject-specific config files, unless overridden. 
+All subject information and processing parameters are specified in a subject-specific configuration file. Default configuration settings are defined in `config/base_config.py`, which can be duplicated and modified to be a subject-specific config file. The standard config parameters in the file must be filled per subject. Any absent variables in the subject-specific config file are inherited from `base_config.py`
 
 #### 3.1.3 Processing a subject
 


### PR DESCRIPTION
## Summary

<!-- What does this PR do? -->

This PR updates section 3.1.2 of the README discussing config files to reflect the current config setup in the repo per [PR#88](https://github.com/TeamXenonDuke/xenon-gas-exchange-consortium/pull/88).

## Changes

<!-- What features/files were changed? -->

* Deleted references to any demo_configs
* Directed users to duplicate base_config & modify required parameters per subject

## Testing Instructions

<!-- How do we ensure the code works as expected? -->

1. Scroll to section 3.1.2 of README
2. Follow instructions on how to use config files
3. Determine wording is understandable to a new user

## Screenshots (if applicable)
Before
<img width="868" height="491" alt="image" src="https://github.com/user-attachments/assets/72a72f11-a0d9-4631-9760-907c41786fb0" />

After
<img width="859" height="166" alt="image" src="https://github.com/user-attachments/assets/6557451c-c787-4bfa-86d8-e3d0cab12b2c" />
