### PR TITLE
add normalization method to report cover page

### DIFF
--- a/assets/html/intro.html
+++ b/assets/html/intro.html
@@ -234,7 +234,12 @@
           </td>
           <td>{corrected_lung_volume}</td>
         </tr>
-
+       <tr class="basic">
+          <td>
+            <p>Vent Normalization Method</p>
+          </td>
+          <td>{vent_normalization_method}</td>
+        </tr>
         <tr class="basic">
           <td>
             <p>Reference Data</p>

--- a/config/base_config.py
+++ b/config/base_config.py
@@ -44,7 +44,7 @@ class Config(config_dict.ConfigDict):
         self.bag_volume = "None"
         self.segmentation_key = constants.SegmentationKey.CNN_VENT.value
         self.manual_seg_filepath = ""
-        # default 99th percentile rescaling method
+        # Choose NormalizationMethod from PERCENTILE_MASKED, FRAC_VENT, MEAN_ANCHOR (PERCENTILE_MASKED is default)!
         self.vent_normalization_method = constants.NormalizationMethods.PERCENTILE_MASKED
         # auto-generate if filepath missing or file not found
         self.auto_make_trachea_plus_lung_mask = True

--- a/main.py
+++ b/main.py
@@ -83,9 +83,9 @@ def gx_mapping_readin(config: base_config.Config):
         config (config_dict.ConfigDict): config dict
     """
     subject = Subject(config=config)
-    if config.vent_normalization_method not in ["PERCENTILE_MASKED", "FRAC_VENT", "MEAN_ANCHOR"]:
+    if config.vent_normalization_method not in ["percentile_masked", "frac_vent", "mean_anchor"]:
         msg = (
-            "Wrong normalization method! You should choose: PERCENTILE_MASKED, FRAC_VENT, or MEAN_ANCHOR"
+            f"You choose a wrong normalization method: {config.vent_normalization_method}! It has to be: PERCENTILE_MASKED, FRAC_VENT, or MEAN_ANCHOR"
         )
         raise ValueError(msg)
     subject.read_mat_file()

--- a/main.py
+++ b/main.py
@@ -26,9 +26,9 @@ def gx_mapping_reconstruction(config: base_config.Config):
         config (config_dict.ConfigDict): config dict
     """
     subject = Subject(config=config)
-    if config.vent_normalization_method not in ["PERCENTILE_MASKED", "FRAC_VENT", "MEAN_ANCHOR"]:
+    if config.vent_normalization_method not in ["percentile_masked", "frac_vent", "mean_anchor"]:
         msg = (
-            "Wrong normalization method! You should choose: PERCENTILE_MASKED, FRAC_VENT, or MEAN_ANCHOR"
+            f"You choose a wrong normalization method: {config.vent_normalization_method}! It has to be: PERCENTILE_MASKED, FRAC_VENT, or MEAN_ANCHOR"
         )
         raise ValueError(msg)
     try:

--- a/main.py
+++ b/main.py
@@ -26,6 +26,11 @@ def gx_mapping_reconstruction(config: base_config.Config):
         config (config_dict.ConfigDict): config dict
     """
     subject = Subject(config=config)
+    if config.vent_normalization_method not in ["PERCENTILE_MASKED", "FRAC_VENT", "MEAN_ANCHOR"]:
+        msg = (
+            "Wrong normalization method! You should choose: PERCENTILE_MASKED, FRAC_VENT, or MEAN_ANCHOR"
+        )
+        raise ValueError(msg)
     try:
         subject.read_twix_files()
     except:
@@ -78,6 +83,11 @@ def gx_mapping_readin(config: base_config.Config):
         config (config_dict.ConfigDict): config dict
     """
     subject = Subject(config=config)
+    if config.vent_normalization_method not in ["PERCENTILE_MASKED", "FRAC_VENT", "MEAN_ANCHOR"]:
+        msg = (
+            "Wrong normalization method! You should choose: PERCENTILE_MASKED, FRAC_VENT, or MEAN_ANCHOR"
+        )
+        raise ValueError(msg)
     subject.read_mat_file()
     if FLAGS.force_segmentation:
         subject.segmentation()

--- a/subject_classmap.py
+++ b/subject_classmap.py
@@ -973,6 +973,7 @@ class Subject(object):
             constants.IOFields.TE90: 1e6 * self.dict_dis[constants.IOFields.TE90],
             constants.IOFields.TR_DIS: 1e3 * self.dict_dis[constants.IOFields.TR],
             constants.IOFields.USER_LUNG_VOLUME_VALUE:self.user_lung_volume_value,
+            constants.IOFields.VENT_NORMALIZATION_METHOD: self.config.vent_normalization_method
         }
         return self.dict_info
 

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -82,6 +82,7 @@ class IOFields(object):
     VOL_CORRECTION_KEY = "vol_correction_key"
     VOL_CORRECTION_FACTOR_MEMBRANE  = "vol_correction_factor_membrane"
     VOL_CORRECTION_FACTOR_RBC = "vol_correction_factor_rbc"
+    VENT_NORMALIZATION_METHOD = "vent_normalization_method"
     CORRECTED_LUNG_VOLUME = "corrected_lung_volume"
     PREP_PULSES = "prep_pulses"
 

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -362,12 +362,14 @@ class PDFOPTIONS(object):
 
 class NormalizationMethods(object):
     """Image normalization methods."""
+    # For increasing the image contrast
+    MAX = "max"  # Normalize by the global maximum intensity in the image (increase contrast, not currently used)
+    PERCENTILE = "percentile"  # Normalize by a given percentile of the entire image (increase proton contrast)
+    MEAN = "mean"  # Normalize by the mean intensity within the mask (deep learning segmetation)
 
-    MAX = "max"  # Normalize by the global maximum intensity in the image
+    # For histogram normalization
     PERCENTILE_MASKED = "percentile_masked"  # Normalize by a given percentile computed only within the mask
     FRAC_VENT = "frac_vent"  # Normalize to estimate fractional ventilation using bag volume and voxel size
-    PERCENTILE = "percentile"  # Normalize by a given percentile of the entire image
-    MEAN = "mean"  # Normalize by the mean intensity within the mask
     MEAN_ANCHOR = "mean_anchor" # MEAN_ANCHOR: normalize to unit-mean inside mask (like MEAN), then clip high outliers at the masked 99th percentile to stabilize scaling.
 
 


### PR DESCRIPTION
## Summary

We have six different normalization methods:
```
    MAX = "max"  # Normalize by the global maximum intensity in the image
    PERCENTILE_MASKED = "percentile_masked"  # Normalize by a given percentile computed only within the mask
    FRAC_VENT = "frac_vent"  # Normalize to estimate fractional ventilation using bag volume and voxel size
    PERCENTILE = "percentile"  # Normalize by a given percentile of the entire image
    MEAN = "mean"  # Normalize by the mean intensity within the mask
    MEAN_ANCHOR = "mean_anchor" # MEAN_ANCHOR: normalize to unit-mean inside mask (like MEAN), then clip high outliers at the masked 99th percentile to stabilize scaling.
```
So it is better for reader to understand which method we used for the analysis the report.

## Changes

*Add vent_normalization_method in cover page.

## Testing Instructions

1. Check if vent_normalization_method is showing up in the report correctly.

## Screenshots (if applicable)
<img width="499" height="521" alt="image" src="https://github.com/user-attachments/assets/e1e57169-dc29-40c3-889b-c062ddedb807" />
