### PR TITLE
Allow user to specify gx output folder in config

### DIFF
--- a/config/base_config.py
+++ b/config/base_config.py
@@ -21,6 +21,7 @@ class Config(config_dict.ConfigDict):
         hb: float, subject hb value in g/dL
         manual_reg_filepath: str, path to manual registration nifti file
         manual_seg_filepath: str, path to the manual segmentation nifti file
+        output_folder: str, name of folder to output gx files
         dicom_proton_dir: str, path to the DICOM proton images
         processes: Process, the evaluation processes
         rbc_m_ratio: float, the RBC to M ratio from spectroscopy
@@ -29,7 +30,7 @@ class Config(config_dict.ConfigDict):
         remove_noisy_projections: bool, whether to remove noisy projections
         segmentation_key: str, the segmentation key (CNN_VENT, MANUAL)
         subject_id: str, the subject id
-        vol_correction_key: str,lung vollume correction key (NONE, RBC_AND_MEMBRANE)
+        vol_correction_key: str,lung volume correction key (NONE, RBC_AND_MEMBRANE)
         corrected_lung_volume: float, target lung volume in L
     """
 
@@ -63,6 +64,7 @@ class Config(config_dict.ConfigDict):
         self.multi_echo = False
         self.registration_key = constants.RegistrationKey.SKIP.value
         self.manual_reg_filepath = ""
+        self.output_folder = "gx"
 
         # Additional options for contamination correction
         self.phase_gas_acq_diss = "None" #degree

--- a/subject_classmap.py
+++ b/subject_classmap.py
@@ -1332,7 +1332,7 @@ class Subject(object):
             "tmp/rbc2gas_rgb.nii",
         )
         # move files
-        subfolder = os.path.join(self.config.data_dir, "gx")
+        subfolder = os.path.join(self.config.data_dir,self.config.output_folder)
         os.makedirs(subfolder, exist_ok=True)
         io_utils.move_files(output_files, subfolder)
 

--- a/utils/mask_include_trachea.py
+++ b/utils/mask_include_trachea.py
@@ -73,7 +73,7 @@ def get_or_make_mask_include_trachea(
 
     # Default output dir: <data_dir>/gx
     data_dir = str(getattr(config, "data_dir", "") or "").strip() or "."
-    out_dir = os.path.join(data_dir, "gx")
+    out_dir = os.path.join(data_dir,str(getattr(config, "output_folder", "") or "").strip() or ".")
     os.makedirs(out_dir, exist_ok=True)
 
     # Default output name: mask_include_trachea.nii


### PR DESCRIPTION
## Summary

<!-- What does this PR do? -->
This PR allows the user to specify the name of the output folder for gx files in configs. If the subject config does not specify an output folder, the base config defaults to the original "gx" output folder.

## Changes

<!-- What features/files were changed? -->

* config/base_config.py - added self.output_folder variable
* subject_classmap.py -  modified move_output_files() to refer to config for subfolder name
* utils/mask_include_trachea.py - modified out_dir variable to refer to config for subfolder name

## Testing Instructions

<!-- How do we ensure the code works as expected? -->

1. Run gx pipeline on subject without using self.output_folder in your subject config
2. Make sure output files are put in the "gx" folder by default
3. Add self.output_folder to your subject config & enter a unique folder name
4. Rerun gx pipeline on subject & make sure output folder are put in the folder name you specified
5. Repeat steps 1-4, but set `self.auto_make_trachea_plus_lung_mask = False` in config

## Screenshots (if applicable)
