### PR TITLE
Default to CPU if GPU processing fails

### DIFF
--- a/reconstruction.py
+++ b/reconstruction.py
@@ -98,9 +98,12 @@ def reconstruct_cs(
     num_normal = 8
     # set device
     devnum = 0
-    device = sp.Device(devnum)
-    if devnum == -1:
+    try: 
+        device = sp.Device(devnum)
+        logging.info("Using GPU for compressed sensing reconstruction")
+    except Exception: 
         device = sp.cpu_device
+        logging.info("Defaulting to CPU for compressed sensing reconstruction")
     xp = device.xp
     # create sensitivity map
     sense_map = np.ones(


### PR DESCRIPTION
## Summary

<!-- What does this PR do? -->
This PR allows those without a dedicated GPU to perform compressed sensing reconstruction of GX and oscillation images without needing to code hack. 

## Changes

<!-- What features/files were changed? -->

* reconstruction.py -- try/except block that first tries to initialize a GPU and defaults to the CPU if the GPU fails

## Testing Instructions

<!-- How do we ensure the code works as expected? -->

1. Choose your favorite subject for GX and oscillation analysis
2. In the config, set `self.recon_key` and `self.osc_recon_key` to `constants.ReconKey.PLUMMER.value`
3. Set `self.oscillation_analysis` to `True`
4. Run pipeline
5. Personal computer without GPU: ensure the terminal says "Defaulting to CPU for compressed sensing reconstruction"; give yourself enough time to wait for reconstruction (I expect anywhere from 10-30 minutes)
6. Deep Xenon: ensure the terminal says "Using GPU for compressed sensing reconstruction"
7. (If able) verify that personal computer CS recons match deep xenon CS recons

Helpful tip: Use the logging timestamps in the terminal to determine how long processing took with CPU

## Screenshots (if applicable)
