### PR TITLE
Fixes #224 -- Fix Shifting Approach for Correcting Oscillation Images

### DIFF
--- a/utils/img_utils.py
+++ b/utils/img_utils.py
@@ -19,6 +19,7 @@ import pandas as pd
 
 from utils import constants, io_utils, metrics
 
+
 def remove_small_objects(mask: np.ndarray, scale: float = 0.1):
     """Remove small unconnected voxels in the mask.
 
@@ -312,7 +313,7 @@ def normalize(
         sig_vol_rat = tcv_gas_vol / signal_total
         GLB_FV = (image * sig_vol_rat) / voxel_vol
         nifti_img = nb.Nifti1Image(GLB_FV, affine=np.eye(4))
-        nifti_img.to_filename('tmp/GLB_FV_output.nii')
+        nifti_img.to_filename("tmp/GLB_FV_output.nii")
         GLB_FV_mask = GLB_FV[mask == 1]
         flat_array = GLB_FV_mask.flatten()
         mean = np.mean(flat_array)
@@ -474,9 +475,9 @@ def calculate_corrected_rbc_oscillation(
     )
     corrected_oscillations = (
         np.multiply(
-            correction_map, (raw_oscillations - np.min(raw_oscillations) - 0.01)
+            correction_map, (raw_oscillations - np.min(raw_oscillations[mask]) - 0.01)
         )
-        + np.min(raw_oscillations)
+        + np.min(raw_oscillations[mask])
         + 0.01
     )
     return (relative_vc_map, correction_map, corrected_oscillations)


### PR DESCRIPTION

## Summary

<!-- What does this PR do? --> Correcting oscillations for capillary blood volume requires first shifting all values to be positive. This PR modifies the shift such that it is based on the minimum amplitude within the lung mask only, rather than the minimum across the entire image space. This prevents over-shifting by nonsensical values outside the lung mask, which then leads to over-corrected oscillation images.

## Changes

<!-- What features/files were changed? --> img_utils.calculate_corrected_oscillations was modified so that raw oscillations are shifted up (then back down after correction) by np.min(raw_oscillations[mask]) as opposed to np.min(raw_oscillations)

*

## Testing Instructions

<!-- How do we ensure the code works as expected? -->

Run oscillation imaging with correction for capillary blood volume on the main branch.
Then run it again in the new branch. 
Compare.

The correction should look less extreme in the new branch.
I would recommend running 009-054B.

## Screenshots (if applicable)
