### PR TITLE
Fix output folder fallback logic

### DIFF
--- a/subject_classmap.py
+++ b/subject_classmap.py
@@ -1995,7 +1995,10 @@ class Subject(object):
         )
 
         # move files
-        subfolder = os.path.join(self.config.data_dir,self.config.output_folder)
+        try:
+        	subfolder = os.path.join(self.config.data_dir,self.config.output_folder)
+        except:
+        	subfolder = os.path.join(self.config.data_dir, "gx")
         os.makedirs(subfolder, exist_ok=True)
         io_utils.move_files(output_files, subfolder)
 

--- a/utils/mask_include_trachea.py
+++ b/utils/mask_include_trachea.py
@@ -79,7 +79,10 @@ def get_or_make_mask_include_trachea(
 
     # Default output dir: <data_dir>/gx
     data_dir = str(getattr(config, "data_dir", "") or "").strip() or "."
-    out_dir = os.path.join(data_dir,str(getattr(config, "output_folder", "") or "").strip() or ".")
+    if str(getattr(config, "output_folder", "") or "") != "":
+    	out_dir = os.path.join(data_dir,str(getattr(config, "output_folder", "") or "").strip() or ".")
+    else:
+    	out_dir = os.path.join(data_dir,"gx")
     os.makedirs(out_dir, exist_ok=True)
 
     # Default output name: mask_include_trachea.nii


### PR DESCRIPTION
## Summary

<!-- What does this PR do? -->
This PR fixes fallback logic if output folder is not specified in subject config
## Changes

<!-- What features/files were changed? -->

* subject_classmap.py - check if output folder specified. if not, manually default to "gx"
* utils/mask_include_trachea.py - same idea as above 

## Testing Instructions

<!-- How do we ensure the code works as expected? -->

1. Process subject with `self.output_folder` missing from subject config
2. Confirm "gx" folder is created in subject directory and output files are moved there
3. Process subject with `self.output_folder` set in subject config
4. Confirm your specified folder is created in subject directory and output files are moved there

## Screenshots (if applicable)
