### PR TITLE
constrained the shift applied for oscillation correction to -3 SD thr…

### DIFF
--- a/utils/img_utils.py
+++ b/utils/img_utils.py
@@ -473,13 +473,19 @@ def calculate_corrected_rbc_oscillation(
     raw_oscillations = calculate_rbc_oscillation(
         image_high, image_low, image_total, mask, method
     )
-    corrected_oscillations = (
-        np.multiply(
-            correction_map, (raw_oscillations - np.min(raw_oscillations[mask]) - 0.01)
+    if np.min(raw_oscillations[mask]) > -4.02:  # -3 SD healthy reference osc threshold
+        corrected_oscillations = (
+            np.multiply(
+                correction_map,
+                (raw_oscillations - np.min(raw_oscillations[mask]) + 0.01),
+            )
+            + np.min(raw_oscillations[mask])
+            - 0.01
         )
-        + np.min(raw_oscillations[mask])
-        + 0.01
-    )
+    else:
+        corrected_oscillations = (
+            np.multiply(correction_map, (raw_oscillations + 4.02 + 0.01)) - 4.02 - 0.01
+        )
     return (relative_vc_map, correction_map, corrected_oscillations)
 
 


### PR DESCRIPTION
…eshold of the healthy reference distribution to limit over-shifting/over-correcting

## Summary

<!-- What does this PR do? --> Mitigate over-correction of oscillation images in patients with some super low baseline values. These values drive up the applied shift, which leads to drastic over-correction, so we have constrained the shift to make sure it is always reasonably small without impacting binning too much. 

## Changes

<!-- What features/files were changed? -->

Constrain the upward shift in correcting rbc oscillation images to a threshold of (reference mean - 3 SD). That is, if a subject's minimum amplitude is greater than this threshold, we perform our usual shifting so that all values become positive before correction. If the minimum amplitude is less than or equal to that threshold, then we only shift up by that threshold value, so that only values below that become positive before correction.  

## Testing Instructions

<!-- How do we ensure the code works as expected? -->

1. Run oscillation imaging with Vc' correction in the main branch and in this branch and compare.
2. Select a subject that has a very low minimum amplitude at baseline (ex. 009-044B) to see the benefits
3. Test in a healthy subject with very few low baseline oscillations to confirm that these subjects don't get messed up

## Screenshots (if applicable)
