### PR TITLE
#225: Make Mat Files Temp

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ conda activate <name-of-conda-environment>
 
 #### 3.1.1 Accepted file inputs
 
-The pipeline accepts Siemens twix (.dat) or ISMRMRD (.h5) files for standard proton UTE, 1-point Dixon, and (optionally) calibration scans. Alternatively, if a subject scan has already been processed through the pipeline and you wish to reprocess the previously constructed images, you can run the pipeline on the subject's .mat file. ISMRMRD files must be named and formatted according to the <sup>129</sup>Xe MRI clinical trials consortium specifications: [https://github.com/Xe-MRI-CTC/xemrd-specification](https://github.com/Xe-MRI-CTC/xemrd-specification)
+The pipeline accepts Siemens twix (.dat) or ISMRMRD (.h5) files for standard proton UTE, 1-point Dixon, and (optionally) calibration scans. ISMRMRD files must be named and formatted according to the <sup>129</sup>Xe MRI clinical trials consortium specifications: [https://github.com/Xe-MRI-CTC/xemrd-specification](https://github.com/Xe-MRI-CTC/xemrd-specification)
 
 More information on consortium protocol for the proton UTE, 1-point Dixon, and calibration scans can be found in the following reference:
 
@@ -176,14 +176,6 @@ Run the full pipeline with:
 
 ```bash
 python main.py --config <path-to-config-file>
-```
-
-#### Running previously processed subject scan from .mat file
-
-If a subject scan has already been processed through the pipeline and you wish to reprocess the previously constructed images, you can run the pipeline on the subject's .mat file with:
-
-```bash
-python main.py --config <path-to-config-file> --force_readin
 ```
 
 ### 3.2. Team Xenon Worflow for Duke Data Processing

--- a/subject_classmap.py
+++ b/subject_classmap.py
@@ -1318,10 +1318,15 @@ class Subject(object):
 
     def move_output_files(self):
         """Move output files into dedicated directory."""
-        # define files to move
+        # Keep only the current subject's .mat file in tmp, remove any others left behind from previously processed subjects.
+        current_mat = "tmp/{}.mat".format(self.config.subject_id)
+        for stale_mat in glob.glob("tmp/*.mat"):
+            if stale_mat != current_mat:
+                os.remove(stale_mat)
+
+        # define files to move into permanent patient folder 
         output_files = (
             "tmp/{}_config_gx_imaging.json".format(self.config.subject_id),
-            "tmp/{}.mat".format(self.config.subject_id),
             "tmp/{}_report.pdf".format(self.config.subject_id),
             "tmp/{}_stats.csv".format(self.config.subject_id),
             "tmp/gas_highreso.nii",
@@ -1329,10 +1334,13 @@ class Subject(object):
             "tmp/mask_reg.nii",
             "tmp/membrane2gas_rgb.nii",
             "tmp/proton_reg.nii",
-            "tmp/rbc2gas_rgb.nii",
-        )
+            "tmp/rbc2gas_rgb.nii",       
+        )  
         # move files
-        subfolder = os.path.join(self.config.data_dir, "gx")
+        try:
+            subfolder = os.path.join(self.config.data_dir,self.config.output_folder)
+        except:
+            subfolder = os.path.join(self.config.data_dir, "gx")
         os.makedirs(subfolder, exist_ok=True)
         io_utils.move_files(output_files, subfolder)
 


### PR DESCRIPTION
## Summary

<!-- What does this PR do? -->

This pull request exports our favourite .mat files to the temporary folder "tmp" instead of permanently in the patient file. This is to save file size.

<!-- What features/files were changed? -->

The .mat was removed from the output_files list and instead kept in the temp folder. When a new patient is ran, the script now checks to see if there is an old .mat file for it to replace in that temp folder. 

## Testing Instructions

<!-- How do we ensure the code works as expected? -->

Test a couple of patients and see if the .mat file is properly overwritten between them, and if there is a .mat file in the gx folder anymore after having run it. There should no longer be a .mat file in gx, and the .mat file in tmp should be overwritten between each patient. 

