### PR TITLE
Make .mat files temporary

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ conda activate <name-of-conda-environment>
 
 #### 3.1.1 Accepted file inputs
 
-The pipeline accepts Siemens twix (.dat) or ISMRMRD (.h5) files for standard proton UTE, 1-point Dixon, and (optionally) calibration scans. Alternatively, if a subject scan has already been processed through the pipeline and you wish to reprocess the previously constructed images, you can run the pipeline on the subject's .mat file. ISMRMRD files must be named and formatted according to the <sup>129</sup>Xe MRI clinical trials consortium specifications: [https://github.com/Xe-MRI-CTC/xemrd-specification](https://github.com/Xe-MRI-CTC/xemrd-specification)
+The pipeline accepts Siemens twix (.dat) or ISMRMRD (.h5) files for standard proton UTE, 1-point Dixon, and (optionally) calibration scans. ISMRMRD files must be named and formatted according to the <sup>129</sup>Xe MRI clinical trials consortium specifications: [https://github.com/Xe-MRI-CTC/xemrd-specification](https://github.com/Xe-MRI-CTC/xemrd-specification)
 
 More information on consortium protocol for the proton UTE, 1-point Dixon, and calibration scans can be found in the following reference:
 
@@ -176,14 +176,6 @@ Run the full pipeline with:
 
 ```bash
 python main.py --config <path-to-config-file>
-```
-
-#### Running previously processed subject scan from .mat file
-
-If a subject scan has already been processed through the pipeline and you wish to reprocess the previously constructed images, you can run the pipeline on the subject's .mat file with:
-
-```bash
-python main.py --config <path-to-config-file> --force_readin
 ```
 
 ### 3.2. Team Xenon Worflow for Duke Data Processing

--- a/main.py
+++ b/main.py
@@ -31,6 +31,7 @@ def gx_mapping_reconstruction(config: base_config.Config):
         config (config_dict.ConfigDict): config dict
     """
     subject = Subject(config=config)
+    subject.clear_temp_file()
     if config.vent_normalization_method not in ["glb_99", "glb_fv", "glb_ma","threshold_ma"]:
         msg = (
             f"You choose a wrong normalization method: {config.vent_normalization_method}! It has to be: GLB_99, GLB_FV, GLB_MA, or THRESHOLD_MA"
@@ -93,6 +94,7 @@ def gx_mapping_readin(config: base_config.Config):
         config (config_dict.ConfigDict): config dict
     """
     subject = Subject(config=config)
+    subject.clear_temp_file()
     if config.vent_normalization_method not in ["glb_99", "glb_fv", "glb_ma","threshold_ma"]:
         msg = (
             f"You choose a wrong normalization method: {config.vent_normalization_method}! It has to be: GLB_99, GLB_FV, GLB_MA, or THRESHOLD_MA"

--- a/subject_classmap.py
+++ b/subject_classmap.py
@@ -1978,12 +1978,18 @@ class Subject(object):
             "tmp/{}_config_gx_imaging.json".format(self.config.subject_id),
         )
 
+    def clear_temp_file(self):
+        """Clear the temp file in between patients being processed"""
+        for filename in os.listdir("tmp"):
+            filepath = os.path.join("tmp", filename)
+            if os.path.isfile(filepath):
+                os.remove(filepath)
+
     def move_output_files(self):
         """Move output files into dedicated directory."""
         # define files to move
         output_files = (
             "tmp/{}_config_gx_imaging.json".format(self.config.subject_id),
-            "tmp/{}.mat".format(self.config.subject_id),
             "tmp/{}_report.pdf".format(self.config.subject_id),
             "tmp/{}_stats.csv".format(self.config.subject_id),
             "tmp/gas_highreso.nii",

--- a/subject_classmap.py
+++ b/subject_classmap.py
@@ -1981,6 +1981,8 @@ class Subject(object):
     def clear_temp_file(self):
         """Clear the temp file in between patients being processed"""
         for filename in os.listdir("tmp"):
+            if filename == ".gitkeep":
+                continue
             filepath = os.path.join("tmp", filename)
             if os.path.isfile(filepath):
                 os.remove(filepath)


### PR DESCRIPTION
## Summary

<!-- What does this PR do? -->

Made changes to wipe the temp file between patients being ran by creating a function in subject_classmap.py and implementing it in main.py. Also, moved the .mat file to be output to the temp file. Additionally, changed the README file verbiage to no longer support .mat files

<!-- What features/files were changed? -->

I changed three files: the README file to get rid of parts where we mention running the pipeline with .mat files. I added a function into subject_classmap.py called "clear_temp_file()" which wipes the temp file as you run a subject. And finally, I added this function into main.py to make sure that it actually happens. 

## Testing Instructions

<!-- How do we ensure the code works as expected? -->

I tested this on two different subjects, and the .mat file is no longer found in the gx folder, and the tmp folder was cleaned out between runs of the code. 
