### PR TITLE
Appended gx output folder name to osc_imaging folder name

### DIFF
--- a/subject_classmap.py
+++ b/subject_classmap.py
@@ -2019,7 +2019,11 @@ class Subject(object):
                 osc_files = osc_files + ("tmp/osc_binned_color_corr.nii",)
 
             # move files
-            subfolder_osc = os.path.join(self.config.data_dir, "osc_imaging")
+            try:
+                osc_folder_name = "{}_osc_imaging".format(self.config.output_folder)
+            except:
+                osc_folder_name = "osc_imaging"
+            subfolder_osc = os.path.join(self.config.data_dir, osc_folder_name)
             os.makedirs(subfolder_osc, exist_ok=True)
             io_utils.move_files(osc_files, subfolder_osc)
 


### PR DESCRIPTION
## Summary
Changes the hard-coded "osc_imaging" folder to "{gx_output_folder_name}_osc_imaging," so the osc folder and gx folder are now coupled and osc_imaging doesn't get overwritten on multiple runs of differing gx folder names.

## Changes
Changed the osc folder name

## Testing Instructions

<!-- How do we ensure the code works as expected? -->

1. Change self.output_folder in the config file to desired name
2. Observe that output name being appended before in the osc folder

## Screenshots (if applicable)
<img width="1237" height="246" alt="image" src="https://github.com/user-attachments/assets/30c18a77-eca9-4b00-bb3e-333681290f22" />
<img width="1239" height="392" alt="image" src="https://github.com/user-attachments/assets/ef550a12-237d-4453-ba2b-45489908235d" />
<img width="1239" height="245" alt="image" src="https://github.com/user-attachments/assets/11af863a-2062-406d-b55c-93f2b69252db" />
