### PR TITLE
osc recon now inherits gx recon from config

### DIFF
--- a/config/base_config.py
+++ b/config/base_config.py
@@ -147,7 +147,6 @@ class OscillationRecon(object):
         Attributes:
             oscillation_analysis: bool, whether to perform oscillation imaging analysis
             key_radius_pct: int, percentage of points used to recon the keyhole image
-            osc_recon_key: str, the type of reconstruction to perform
             vc_correction: bool, whether to correction oscillation images for relative capillary blood volume
         """
         self.oscillation_analysis = False
@@ -155,9 +154,6 @@ class OscillationRecon(object):
         # Keyhole Radius
         self.key_radius_pct = 14
         # Recon Type
-        # Gridded (Robertson)
-        # Compressed Sensing (Plummer)
-        self.osc_recon_key = constants.ReconKey.ROBERTSON.value
 
         # Correction for relative capillary blood volume
         self.vc_correction = False

--- a/subject_classmap.py
+++ b/subject_classmap.py
@@ -17,19 +17,19 @@ import registration
 import segmentation
 from config import base_config
 from utils import (
-	binning,
-	constants,
-	img_utils,
-	io_utils,
-	metrics,
-	plot,
-	recon_utils,
-	report,
-	signal_utils,
-	spect_utils,
-	traj_utils,
-	git_utils,
-	mask_include_trachea,
+    binning,
+    constants,
+    img_utils,
+    io_utils,
+    metrics,
+    plot,
+    recon_utils,
+    report,
+    signal_utils,
+    spect_utils,
+    traj_utils,
+    git_utils,
+    mask_include_trachea,
 )
 
 
@@ -598,7 +598,7 @@ class Subject(object):
         )
 
         # reconstruction
-        if self.config.osc_recon.osc_recon_key == constants.ReconKey.ROBERTSON.value:
+        if self.config.recon.recon_key == constants.ReconKey.ROBERTSON.value:
             # prepare data and traj for reconstruction
             data_dis_high, traj_dis_high = pp.prepare_data_and_traj_keyhole(
                 data=data_dissolved_norm,
@@ -648,7 +648,7 @@ class Subject(object):
                 orientation=self.dict_dis[constants.IOFields.ORIENTATION],
                 system_vendor=self.dict_dis[constants.IOFields.SYSTEM_VENDOR],
             )
-        elif self.config.osc_recon.osc_recon_key == constants.ReconKey.PLUMMER.value:
+        elif self.config.recon.recon_key == constants.ReconKey.PLUMMER.value:
             # prepare data and traj for reconstruction
             norm_data = np.linalg.norm(self.data_dissolved)
             self.data_dissolved /= norm_data
@@ -804,14 +804,20 @@ class Subject(object):
 
             mask, self.image_proton_reg = np.abs(
                 registration.register_ants(
-                    abs(self.image_gas_highreso), self.mask_proton, self.image_proton, self.config.registration_key
+                    abs(self.image_gas_highreso),
+                    self.mask_proton,
+                    self.image_proton,
+                    self.config.registration_key,
                 )
             )
         elif self.config.registration_key == constants.RegistrationKey.PROTON2GAS.value:
             logging.info("Run registration algorithm, vent is fixed, proton is moving")
             self.image_proton_reg, mask = np.abs(
                 registration.register_ants(
-                    abs(self.image_gas_highreso), self.image_proton, self.mask, self.config.registration_key
+                    abs(self.image_gas_highreso),
+                    self.image_proton,
+                    self.mask,
+                    self.config.registration_key,
                 )
             )
 
@@ -884,21 +890,29 @@ class Subject(object):
     def gas_binning(self):
         """Bin gas images to colormap bins."""
 
-        if self.config.vent_normalization_method == constants.NormalizationMethods.GLB_99:
+        if (
+            self.config.vent_normalization_method
+            == constants.NormalizationMethods.GLB_99
+        ):
             self.image_gas_binned = binning.linear_bin(
                 image=self._normalize_vent(self.image_gas_cor),
                 mask=self.mask,
                 thresholds=self.reference_data[
-                    'threshold_vent_nb'
-                    if self.config.bias_key == constants.BiasfieldKey.SKIP.value
-                    else 'threshold_vent'
+                    (
+                        "threshold_vent_nb"
+                        if self.config.bias_key == constants.BiasfieldKey.SKIP.value
+                        else "threshold_vent"
+                    )
                 ],
             )
             self.mask_vent = np.logical_and(self.image_gas_binned > 1, self.mask)
             gas_nifti_img = nib.Nifti1Image(self.image_gas_binned, affine=np.eye(4))
             gas_nifti_img.to_filename("tmp/image_gas_binned.nii")
 
-        elif self.config.vent_normalization_method == constants.NormalizationMethods.GLB_FV:
+        elif (
+            self.config.vent_normalization_method
+            == constants.NormalizationMethods.GLB_FV
+        ):
             self.image_gas_binned = binning.linear_bin(
                 image=self._normalize_vent(self.image_gas_cor),  # big mask here
                 mask=self.mask,
@@ -907,26 +921,34 @@ class Subject(object):
             self.mask_vent = np.logical_and(self.image_gas_binned > 1, self.mask)
 
             gas_nifti_img = nib.Nifti1Image(self.image_gas_binned, affine=np.eye(4))
-            gas_nifti_img.to_filename('tmp/image_gas_binned_GLB_FV.nii')
-        elif self.config.vent_normalization_method == constants.NormalizationMethods.GLB_MA:
+            gas_nifti_img.to_filename("tmp/image_gas_binned_GLB_FV.nii")
+        elif (
+            self.config.vent_normalization_method
+            == constants.NormalizationMethods.GLB_MA
+        ):
             self.image_gas_binned = binning.linear_bin(
                 image=self._normalize_vent(self.image_gas_cor),
                 mask=self.mask,
                 thresholds=self.reference_data[
-                    'threshold_vent_mean_anchor_nb'
-                    if self.config.bias_key == constants.BiasfieldKey.SKIP.value
-                    else 'threshold_vent_mean_anchor'
+                    (
+                        "threshold_vent_mean_anchor_nb"
+                        if self.config.bias_key == constants.BiasfieldKey.SKIP.value
+                        else "threshold_vent_mean_anchor"
+                    )
                 ],
             )
             self.mask_vent = np.logical_and(self.image_gas_binned > 1, self.mask)
             gas_nifti_img = nib.Nifti1Image(self.image_gas_binned, affine=np.eye(4))
-            gas_nifti_img.to_filename('tmp/image_gas_binned.nii')
-        elif self.config.vent_normalization_method == constants.NormalizationMethods.THRESHOLD_MA:
+            gas_nifti_img.to_filename("tmp/image_gas_binned.nii")
+        elif (
+            self.config.vent_normalization_method
+            == constants.NormalizationMethods.THRESHOLD_MA
+        ):
             self.image_gas_binned = binning.threshold(
-            image=self._normalize_vent(self.image_gas_cor),
-            mask=self.mask,
-            threshold= constants.THRESHOLD_MA,
-        )
+                image=self._normalize_vent(self.image_gas_cor),
+                mask=self.mask,
+                threshold=constants.THRESHOLD_MA,
+            )
             self.mask_vent = np.logical_and(self.image_gas_binned > 1, self.mask)
             gas_nifti_img = nib.Nifti1Image(self.image_gas_binned, affine=np.eye(4))
             gas_nifti_img.to_filename("tmp/image_gas_binned.nii")
@@ -1303,7 +1325,9 @@ class Subject(object):
             rbcm_ref = metrics.rbcm_ref(age, sex)
             if pd.notna(rbcm_ref) and rbcm_ref != 0:
                 self.dict_stats[constants.IOFields.RBCM_REF] = rbcm_ref
-                self.dict_stats[constants.IOFields.RBCM_PERC] = round(100 * self.rbc_m_ratio / rbcm_ref)
+                self.dict_stats[constants.IOFields.RBCM_PERC] = round(
+                    100 * self.rbc_m_ratio / rbcm_ref
+                )
         else:
             self.dict_stats[constants.IOFields.RBCM_REF] = "NA"
             self.dict_stats[constants.IOFields.RBCM_PERC] = "NA"
@@ -1643,7 +1667,12 @@ class Subject(object):
             thresholds=self._vent_hist_thresholds(),
             band_colors=constants.CMAP.VENT_BIN2COLOR,  # per-segment bar colors (bin 0 ignored)
             outline="data",
-            refer_threshold = constants.THRESHOLD_MA if self.config.vent_normalization_method == constants.NormalizationMethods.THRESHOLD_MA else None,
+            refer_threshold=(
+                constants.THRESHOLD_MA
+                if self.config.vent_normalization_method
+                == constants.NormalizationMethods.THRESHOLD_MA
+                else None
+            ),
         )
         plot.plot_histogram(
             data=np.abs(self.image_rbc2gas)[
@@ -1950,8 +1979,19 @@ class Subject(object):
             "tmp/gas_rgb.nii",
         )
 
-        if self.config.vent_normalization_method == constants.NormalizationMethods.GLB_FV: 
-            io_utils.export_nii(img_utils.normalize(self.image_gas_cor,self.mask_include_trachea, bag_volume=self.config.bag_volume, method=constants.NormalizationMethods.GLB_FV), "tmp/GLB_FV.nii")
+        if (
+            self.config.vent_normalization_method
+            == constants.NormalizationMethods.GLB_FV
+        ):
+            io_utils.export_nii(
+                img_utils.normalize(
+                    self.image_gas_cor,
+                    self.mask_include_trachea,
+                    bag_volume=self.config.bag_volume,
+                    method=constants.NormalizationMethods.GLB_FV,
+                ),
+                "tmp/GLB_FV.nii",
+            )
         if self.config.osc_recon.oscillation_analysis:
             io_utils.export_nii_4d(
                 plot.map_grey_to_rgb(
@@ -2004,9 +2044,9 @@ class Subject(object):
 
         # move files
         try:
-        	subfolder = os.path.join(self.config.data_dir,self.config.output_folder)
+            subfolder = os.path.join(self.config.data_dir, self.config.output_folder)
         except:
-        	subfolder = os.path.join(self.config.data_dir, "gx")
+            subfolder = os.path.join(self.config.data_dir, "gx")
         os.makedirs(subfolder, exist_ok=True)
         io_utils.move_files(output_files, subfolder)
 
@@ -2119,11 +2159,18 @@ class Subject(object):
 
         if method == constants.NormalizationMethods.GLB_FV:
             return f.YTICKLABELS_GLB_FV
-        elif method in (constants.NormalizationMethods.GLB_MA, constants.NormalizationMethods.THRESHOLD_MA):
+        elif method in (
+            constants.NormalizationMethods.GLB_MA,
+            constants.NormalizationMethods.THRESHOLD_MA,
+        ):
             if self.config.bias_key == constants.BiasfieldKey.SKIP.value:
-                    return f.YTICKLABELS_GLB_MA_NB  # define in constants if you want custom labels
+                return (
+                    f.YTICKLABELS_GLB_MA_NB
+                )  # define in constants if you want custom labels
             else:
-                    return f.YTICKLABELS_GLB_MA  # define in constants if you want custom labels
+                return (
+                    f.YTICKLABELS_GLB_MA
+                )  # define in constants if you want custom labels
         else:
             return f.YTICKLABELS
 
@@ -2143,9 +2190,14 @@ class Subject(object):
 
         if method == constants.NormalizationMethods.GLB_FV:
             return f.YLIM_GLB_FV
-        elif method in (constants.NormalizationMethods.GLB_MA, constants.NormalizationMethods.THRESHOLD_MA):
+        elif method in (
+            constants.NormalizationMethods.GLB_MA,
+            constants.NormalizationMethods.THRESHOLD_MA,
+        ):
             if self.config.bias_key == constants.BiasfieldKey.SKIP.value:
-                return f.YLIM_GLB_MA_NB  # define in constants if you want a custom range
+                return (
+                    f.YLIM_GLB_MA_NB
+                )  # define in constants if you want a custom range
             else:
                 return f.YLIM_GLB_MA  # define in constants if you want a custom range
         else:
@@ -2159,9 +2211,14 @@ class Subject(object):
         f = constants.VENTHISTOGRAMFields
         method = self.config.vent_normalization_method
 
-        if method in (constants.NormalizationMethods.GLB_MA, constants.NormalizationMethods.THRESHOLD_MA):
+        if method in (
+            constants.NormalizationMethods.GLB_MA,
+            constants.NormalizationMethods.THRESHOLD_MA,
+        ):
             if self.config.bias_key == constants.BiasfieldKey.SKIP.value:
-                return f.XLIM_GLB_MA_NB  # define in constants if you want a custom range
+                return (
+                    f.XLIM_GLB_MA_NB
+                )  # define in constants if you want a custom range
             else:
                 return f.XLIM_GLB_MA  # define in constants if you want a custom range
         else:
@@ -2175,7 +2232,10 @@ class Subject(object):
         f = constants.VENTHISTOGRAMFields
         method = self.config.vent_normalization_method
 
-        if method in (constants.NormalizationMethods.GLB_MA, constants.NormalizationMethods.THRESHOLD_MA):
+        if method in (
+            constants.NormalizationMethods.GLB_MA,
+            constants.NormalizationMethods.THRESHOLD_MA,
+        ):
             if self.config.bias_key == constants.BiasfieldKey.SKIP.value:
                 return f.XTICKS_GLB_MA_NB  # define in constants
             else:
@@ -2191,7 +2251,10 @@ class Subject(object):
         f = constants.VENTHISTOGRAMFields
         method = self.config.vent_normalization_method
 
-        if method in (constants.NormalizationMethods.GLB_MA, constants.NormalizationMethods.THRESHOLD_MA):
+        if method in (
+            constants.NormalizationMethods.GLB_MA,
+            constants.NormalizationMethods.THRESHOLD_MA,
+        ):
             if self.config.bias_key == constants.BiasfieldKey.SKIP.value:
                 return f.XTICKLABELS_GLB_MA_NB  # define in constants
             else:


### PR DESCRIPTION
## Summary

<!-- What does this PR do? -->

## Changes

oscillation imaging now inherits the recon key specified for gas exchange imaging in the config. The osc_recon_key is now removed entirely from the config file.

Also, I am very sorry for all the format changes on subject_classmap. We have a built in formatting tool on Deep Xenon VSCode, so every time I save changes on this computer, it reformats the code, and all those reformatting changes get lumped into my commits. I actually only made 3 code changes -- the base config, and then the oscillation_reconstruction function in subject_classmap.py

## Testing Instructions

1. Run osc imaging once on main branch with matching gx and osc recon keys
2. Run again on new branch, setting only the gx recon key
3. Verify that outputs match
4. If you wanted to get crazy, you could try it with both robertson and plummer recon keys, and you could also leave the osc recon key on the config in the new branch but set it to the wrong recon key, and it should still give you the correct output.
