### PR TITLE
trachea mask no longer requires reference nii for export

### DIFF
--- a/utils/mask_include_trachea.py
+++ b/utils/mask_include_trachea.py
@@ -6,7 +6,7 @@ import os
 import numpy as np
 import nibabel as nib
 
-from utils import trachea_mask
+from utils import trachea_mask, io_utils
 
 
 def get_or_make_mask_include_trachea(
@@ -59,13 +59,6 @@ def get_or_make_mask_include_trachea(
         )
         return base_lung_mask
 
-    # Internal reference nifti location
-    ref_gas_nii_path = "tmp/image_gas_highreso.nii"
-    if not os.path.exists(ref_gas_nii_path):
-        raise FileNotFoundError(
-            f"Expected {ref_gas_nii_path} to exist for auto trachea mask generation + saving."
-        )
-
     logging.info("Auto-generating trachea mask (Otsu+hysteresis) from gas image array.")
     trach_mask = trachea_mask.otsu_hysteresis_mask_from_nifti(image_gas_highreso)
     trach_mask = np.asarray(trach_mask).astype(bool)
@@ -80,15 +73,17 @@ def get_or_make_mask_include_trachea(
     # Default output dir: <data_dir>/gx
     data_dir = str(getattr(config, "data_dir", "") or "").strip() or "."
     if str(getattr(config, "output_folder", "") or "") != "":
-    	out_dir = os.path.join(data_dir,str(getattr(config, "output_folder", "") or "").strip() or ".")
+        out_dir = os.path.join(
+            data_dir, str(getattr(config, "output_folder", "") or "").strip() or "."
+        )
     else:
-    	out_dir = os.path.join(data_dir,"gx")
+        out_dir = os.path.join(data_dir, "gx")
     os.makedirs(out_dir, exist_ok=True)
 
     # Default output name: mask_include_trachea.nii
     out_path = os.path.join(out_dir, "mask_include_trachea.nii")
 
-    trachea_mask.save_mask_like(ref_gas_nii_path, combined, out_path)
+    io_utils.export_nii(combined.astype(float), out_path)
     logging.info(f"Saved mask_include_trachea to: {out_path}")
 
     # Cache into config

--- a/utils/trachea_mask.py
+++ b/utils/trachea_mask.py
@@ -17,8 +17,7 @@ def _skew_standardized(x: np.ndarray) -> float:
 
 
 def otsu_hysteresis_mask_from_nifti(
-    input_image: np.ndarray,
-    params: Optional[dict] = None
+    input_image: np.ndarray, params: Optional[dict] = None
 ) -> np.ndarray:
     """Return boolean mask (same shape) from a NIfTI image on disk."""
 
@@ -52,8 +51,8 @@ def otsu_hysteresis_mask_from_nifti(
     low_factor = float(np.clip(low_factor, low_clip, high_clip))
     t_low = t_high * low_factor
 
-    seeds = (data >= t_high)
-    region = (data >= t_low)
+    seeds = data >= t_high
+    region = data >= t_low
 
     lab = label(region, connectivity=1)
     seed_ids = np.unique(lab[seeds])
@@ -64,14 +63,6 @@ def otsu_hysteresis_mask_from_nifti(
     closed = binary_closing(connected, ball(radius))
 
     return closed.astype(bool)
-
-
-def save_mask_like(input_path: str, mask_bool: np.ndarray, output_path: str) -> None:
-    """Save mask as uint8 NIfTI using affine/header from input_path."""
-    nii = nib.load(input_path)
-    out = nib.Nifti1Image(mask_bool.astype(np.uint8), affine=nii.affine, header=nii.header)
-    os.makedirs(os.path.dirname(output_path), exist_ok=True)
-    nib.save(out, output_path)
 
 
 def union_masks(mask_a: np.ndarray, mask_b: np.ndarray) -> np.ndarray:


### PR DESCRIPTION
## Summary

Exporting the trachea mask generated for frac vent no longer requires a reference .nii file.

## Changes

Previously, the code searched for gas_highreso.nii in the tmp folder to use as a reference nii for exporting the trachea mask. However, that nii does not get created when using compressed sensing, which then causes an error. Now, we use the export_nii function from utils/io_utils to export the mask nii. 

The only difference is that it is now being saved as a float (0.0 and 1.0) rather than a bool. This is not a problem though, because when reading a pre-existing trachea mask in, the code already converts it to a bool regardless of how it was saved.

## Testing Instructions

1. Set recon key to plummer
2. Set trachea mask to True
3. Run the code
4. Verify that there are no errors and that a trachea mask .nii gets saved to the output folder
5. If you wanted, you could then try to pass in the path to that trachea mask and ensure that the code is still able to read it in

