### PR TITLE
add bmi to cover page

### DIFF
--- a/assets/html/intro.html
+++ b/assets/html/intro.html
@@ -258,7 +258,7 @@
           <td>
             <p>Demographics</p>
           </td>
-          <td>{age}yo. / {sex} / {height}cm / {weight}kg</td>
+          <td>{age}yo. / {sex} / {height}cm / {weight}kg / {bmi}kg/m²</td>
         </tr>
 
         <tr class="basic">

--- a/assets/html/intro.html
+++ b/assets/html/intro.html
@@ -258,7 +258,7 @@
           <td>
             <p>Demographics</p>
           </td>
-          <td>{age}yo. / {sex} / {height}cm / {weight}kg / {bmi}kg/m²</td>
+          <td>{age}yo. / {sex} / {height}cm / {weight}kg / {bmi}kg/m2</td>
         </tr>
 
         <tr class="basic">

--- a/subject_classmap.py
+++ b/subject_classmap.py
@@ -1579,6 +1579,7 @@ class Subject(object):
             constants.IOFields.SEX: self.dict_dis[constants.IOFields.SEX],
             constants.IOFields.HEIGHT: self.dict_dis[constants.IOFields.HEIGHT],
             constants.IOFields.WEIGHT: self.dict_dis[constants.IOFields.WEIGHT],
+            constants.IOFields.BMI: self.dict_dis[constants.IOFields.WEIGHT]/((self.dict_dis[constants.IOFields.HEIGHT]/100)**2),
             constants.IOFields.VENT_NORMALIZATION_METHOD: self.config.vent_normalization_method,
         }
         return self.dict_info

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -27,6 +27,7 @@ class IOFields(object):
     SEX = "sex"
     HEIGHT = "height"
     WEIGHT = "weight"
+    BMI = "bmi"
     GLI_FRC = "gli_frc"
     GLI_VA = "gli_va"
     GLI_KCO = "gli_kco"


### PR DESCRIPTION
## Summary

Adding BMI to the cover page for user to easy to review the report.

## Changes

- add BMI variable in class IOFields in constants.py, and in get_info( ) function to generate the value of bmi, and finally add it to the cover page in intro.html.


## Testing Instructions

Test on this feature branch, and to see if bmi value is included in the GX report cover page.

## Screenshots (if applicable)
<img width="407" height="68" alt="image" src="https://github.com/user-attachments/assets/81ab6d50-2f6e-433e-9fd9-45ef0d9cddee" />
