### PR TITLE
force a fresh install of pip

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -100,7 +100,7 @@ if !([[ "$1" == "build-only" ]] || [[ "$1" == "install-only" ]]); then
     echo "Current env: $CONDA_DEFAULT_ENV"
 
     # pip install and upgrade
-    pip install --upgrade pip
+    conda install pip
 
     # Install gcc to native computer
     if [[ "$OSTYPE" == "linux-gnu"* ]]; then


### PR DESCRIPTION
## Summary

This PR changes one code line in setup.sh from "pip install --upgrade pip" to "conda install pip". That should force a fresh install of pip within the XeGas conda environment. 
This change can help users with pip install under an very old python version, and when using setup.sh to create the XeGas conda environment,it prevents using the old base pip version for the package installations.

## Changes

<!-- What features/files were changed? -->

*setup.sh from "pip install --upgrade pip" to "conda install pip". 

## Testing Instructions

<!-- How do we ensure the code works as expected? -->

Well this test should be good for our new user who is the first time to clone our repository and first time to install all the libraries and packages. Just follow the README instructions to setup/installation process. If everything is installed correctly you can run our GX pipeline successfully.

## Screenshots (if applicable)
